### PR TITLE
Fix default bundler not working with nix 2.8

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -27,16 +27,12 @@
           else (parseDrvName (unsafeDiscardStringContext p.name)).name
       }";
   in {
-
-    # Backwards compatibility helper for pre Nix2.6 bundler API
-    defaultBundler = {__functor = s: {...}@arg:
-      (if arg?program && arg?system then
-        nix-bundle.bundlers.nix-bundle arg
-       else with builtins; listToAttrs (map (system: {
-            name = system;
-            value = drv: self.bundlers.${system}.toArx drv;
-          }) supportedSystems));
-      };
+    defaultBundler = builtins.listToAttrs (map (system: {
+        name = system;
+        value = drv: self.bundlers.${system}.toArx drv;
+      }) supportedSystems)
+      # Backwards compatibility helper for pre Nix2.6 bundler API
+      // {__functor = s: nix-bundle.bundlers.nix-bundle;};
 
     bundlers = let n =
       (forAllSystems (system: {


### PR DESCRIPTION
I don't actually know what the pre Nix2.6 bundler API was, I simply tested this by trying bundle hello with the command
`nix bundle nixpkgs#hello --bundler .#`
while having `nixpkgs#nixVersions.nix_2_{5,6,7,8}` in path.
This seems to work with the listed nix versions, but there might be some other cases where it doesn't. I'm not knowledgeable enough to tell.

This fixes https://github.com/NixOS/bundlers/issues/3