### PR TITLE
Bundle distributable shells

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
     bundlers = let n =
       (forAllSystems (system: {
         # Backwards compatibility helper for pre Nix2.6 bundler API
-        toArx = drv: (nix-bundle.bundlers.nix-bundle ({
+      toArx = drv: (nix-bundle.bundlers.nix-bundle ({
           program = if drv?program then drv.program else (program drv);
           inherit system;
         })) // (if drv?program then {} else {name=
@@ -53,6 +53,17 @@
           tag = "latest";
           contents = [ drv ];
       });
+
+      toShell = drv:
+        let
+          shelldrv = with nixpkgs.legacyPackages.${system}; writeShellApplication {
+            name = drv.name + "-shell";
+            runtimeInputs = drv.buildInputs ++ drv.propagatedBuildInput ++ [ coreutils bash.out ];
+            text = "bash";
+          };
+        in self.bundlers.${system}.toArx shelldrv;
+
+
 
       toBuildDerivation = drv:
         (import ./report/default.nix {


### PR DESCRIPTION
`nix bundle` fails to package `mkShell` derivations however by utilizing `writeShellApplication` to package `bash` with runtime dependencies of a package in scope we can create a distributable shell environment to build a certain package.